### PR TITLE
Don't depend on rubygems

### DIFF
--- a/lib/thrift_client.rb
+++ b/lib/thrift_client.rb
@@ -1,8 +1,5 @@
-require 'rubygems'
-gem 'thrift', '~>0.2.0'
 require 'thrift'
 
-require 'rubygems'
 require 'thrift_client/thrift'
 require 'thrift_client/connection'
 require 'thrift_client/abstract_thrift_client'


### PR DESCRIPTION
It's bad practice adding rubygems as a dependency inside of a gem because you have no possibility choosing another provider.

It'd be cool, if you remove the rubygems dependency by accepting my pull request.

More informations on the topic:
http://www.rubyinside.com/why-using-require-rubygems-is-wrong-1478.html
http://yehudakatz.com/2009/07/24/rubygems-good-practice/
