### PR TITLE
Namespacing the Connection module

### DIFF
--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -79,7 +79,7 @@ class AbstractThriftClient
   # call.
   def connect!
     @current_server = next_live_server
-    @connection = Connection::Factory.create(@options[:transport], @options[:transport_wrapper], @current_server.connection_string, @options[:connect_timeout])
+    @connection = ThriftConnection::Factory.create(@options[:transport], @options[:transport_wrapper], @current_server.connection_string, @options[:connect_timeout])
     @connection.connect!
     @client = @client_class.new(@options[:protocol].new(@connection.transport, *@options[:protocol_extra_params]))
   end

--- a/lib/thrift_client/connection/base.rb
+++ b/lib/thrift_client/connection/base.rb
@@ -1,4 +1,4 @@
-module Connection
+module ThriftConnection
   class Base
     attr_accessor :transport, :server
 

--- a/lib/thrift_client/connection/factory.rb
+++ b/lib/thrift_client/connection/factory.rb
@@ -1,10 +1,10 @@
-module Connection
+module ThriftConnection
   class Factory
     def self.create(transport, transport_wrapper, server, timeout)
       if transport == Thrift::HTTPClientTransport
-        Connection::HTTP.new(transport, transport_wrapper, server, timeout)
+        ThriftConnection::HTTP.new(transport, transport_wrapper, server, timeout)
       else
-        Connection::Socket.new(transport, transport_wrapper, server, timeout)
+        ThriftConnection::Socket.new(transport, transport_wrapper, server, timeout)
       end
     end
   end

--- a/lib/thrift_client/connection/http.rb
+++ b/lib/thrift_client/connection/http.rb
@@ -1,4 +1,4 @@
-module Connection
+module ThriftConnection
   class HTTP < Base
     def connect!
       uri = parse_server(@server)

--- a/lib/thrift_client/connection/socket.rb
+++ b/lib/thrift_client/connection/socket.rb
@@ -1,4 +1,4 @@
-module Connection
+module ThriftConnection
   class Socket < Base
     def close
       @transport.close


### PR DESCRIPTION
Connection is a common module name, and was colliding with the Redis gem in Rails 3. This branch simply renames the Connection module to ThriftConnection.
