### PR TITLE
Add support for specifying client-side timeouts when using FramedTransport

### DIFF
--- a/lib/thrift_client/thrift.rb
+++ b/lib/thrift_client/thrift.rb
@@ -9,6 +9,16 @@ module Thrift
     end
   end
 
+  class FramedTransport
+    def timeout=(timeout)
+      @transport.timeout = timeout
+    end
+
+    def timeout
+      @transport.timeout
+    end
+  end
+
   module Client
     def timeout=(timeout)
       @iprot.trans.timeout = timeout


### PR DESCRIPTION
I noticed that when using FramedTransport, the thrift_client gem doesn't allow me to specify an RPC timeout.

However, the connect_timeout is still applied, and sticks around for the lifetime of the underlying Thrift::Socket, so it's not possible to instantiate a client that has a 1s connect_timeout and say a 10s RPC timeout when using FramedTransport. This does work with BufferedTransport.

The simplest solution is to open the Thrift::FramedTransport class and add a timeout=() method which sets the timeout on the underlying Thrift::Socket.
