### PR TITLE
Reset timeout after connect

### DIFF
--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -81,7 +81,9 @@ class AbstractThriftClient
     @current_server = next_live_server
     @connection = Connection::Factory.create(@options[:transport], @options[:transport_wrapper], @current_server.connection_string, @options[:connect_timeout])
     @connection.connect!
-    @client = @client_class.new(@options[:protocol].new(@connection.transport, *@options[:protocol_extra_params]))
+    transport = @connection.transport
+    transport.timeout = @options[:timeout] if transport_can_timeout?
+    @client = @client_class.new(@options[:protocol].new(transport, *@options[:protocol_extra_params]))
   end
 
   def disconnect!


### PR DESCRIPTION
Currently, the timeout is set in the connection factory to be the connect_timeout param value, and never reset to the global value.

This patch sets the timeout to the (usually longer) general value after the connection is successfully established.
