### PR TITLE
Added exception_classes_without_disconnect

### DIFF
--- a/lib/thrift_client.rb
+++ b/lib/thrift_client.rb
@@ -16,6 +16,7 @@ Valid optional parameters are:
 <tt>:transport</tt>:: Which Thrift transport to use. Defaults to <tt>Thrift::Socket</tt>.
 <tt>:transport_wrapper</tt>:: Which Thrift transport wrapper to use. Defaults to <tt>Thrift::FramedTransport</tt>.
 <tt>:exception_classes</tt>:: Which exceptions to catch and retry when sending a request. Defaults to <tt>[IOError, Thrift::Exception, Thrift::ApplicationException, Thrift::TransportException, NoServersAvailable]</tt>
+<tt>:exception_classes_without_disconnect</tt>:: Some exceptions inherit from Thrift::Exception but do not require a reconnection. These are generally application-specific.
 <tt>:raise</tt>:: Whether to reraise errors if no responsive servers are found. Defaults to <tt>true</tt>.
 <tt>:retries</tt>:: How many times to retry a request. Defaults to 0.
 <tt>:server_retry_period</tt>:: How many seconds to wait before trying to reconnect to a dead server. Defaults to <tt>1</tt>. Set to <tt>nil</tt> to disable.

--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -33,6 +33,7 @@ class AbstractThriftClient
     :raise => true,
     :defaults => {},
     :exception_classes => DISCONNECT_ERRORS,
+    :exception_classes_without_disconnect => [],
     :retries => 0,
     :server_retry_period => 1,
     :server_max_requests => nil,
@@ -128,6 +129,8 @@ class AbstractThriftClient
       end
       @request_count += 1
       @client.send(method_name, *args)
+    rescue *@options[:exception_classes_without_disconnect] => e
+      raise_or_default(e, method_name)
     rescue *@options[:exception_classes] => e
       disconnect_on_error!
       tries ||= (@options[:retry_overrides][method_name.to_sym] || @options[:retries]) + 1


### PR DESCRIPTION
There are some exceptions that inherit from Thrift::Exception that aren't worthy of a reconnection most notably with Cassandra/CQL, an InvalidRequestException .. trivial change.
