### PR TITLE
Updated thrift gem dependency to ">= 0.7.0, < 0.9.0" to allow for thrift-0.8.x compatibility.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.7.2 Updated thrift gem dependency to ">= 0.7.0, < 0.9.0" to allow for thrift-0.8.x compatibility.
+
 v0.7.1 Added support for :before_method and :on_exception callback types.
 Added support for registering multiple callbacks of a given type.
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Echoe.new("thrift_client") do |p|
   p.project = "fauna"
   p.summary = "A Thrift client wrapper that encapsulates some common failover behavior."
   p.rubygems_version = ">= 0.8"
-  p.dependencies = ['thrift ~>0.7.0']
+  p.dependencies = ['thrift >=0.7.0', 'thrift <0.9.0']
   p.ignore_pattern = /^(vendor\/thrift)/
   p.rdoc_pattern = /^(lib|bin|tasks|ext)|^README|^CHANGELOG|^TODO|^LICENSE|^COPYING$/
   p.spec_pattern = "spec/*_spec.rb"


### PR DESCRIPTION
Hey, thrift gem 0.8.0 is released, but can't be used with thrift_client 0.7.1 because of the way the gem dependency is specified right now.

Thrift 0.8.0 is basically a bugfix-only release as far as Ruby libraries are concerned, client code that worked with 0.7.0 is fully compatible with 0.8.0. So, this pull request updates the gem dependency version to allow >= 0.7.0 but < 0.9.0. If 0.9.0 ends up being another fully-compatible release then we can increase the upper bound to 0.10.0 etc.
