### PR TITLE
do not generate #message for #send_message

### DIFF
--- a/lib/thrift_client/abstract_thrift_client.rb
+++ b/lib/thrift_client/abstract_thrift_client.rb
@@ -47,7 +47,7 @@ class AbstractThriftClient
     @callbacks = {}
     @client_methods = []
     @client_class.instance_methods.each do |method_name|
-      if method_name != 'send_message' && method_name =~ /^send_(.*)$/
+      if method_name =~ /^send_(.*)$/ && method_name.to_s != 'send_message'
         instance_eval("def #{$1}(*args); handled_proxy(:'#{$1}', *args); end", __FILE__, __LINE__)
         @client_methods << $1
       end

--- a/test/thrift_client_test.rb
+++ b/test/thrift_client_test.rb
@@ -265,6 +265,11 @@ class ThriftClientTest < Test::Unit::TestCase
     assert_not_equal internal_client, client.client
   end
 
+  def test_wrapper_should_not_generate_message_method
+    client = ThriftClient.new(Greeter::Client, @servers.last, @options)
+    assert !client.respond_to?(:message)
+  end
+
   private
 
   def stub_server(port)


### PR DESCRIPTION
Hi guys, since `#instance_methods` in Ruby 1.9 returns an array of symbols, this tiny patch should fix a bug that `#message` got generated mistakenly in `AbstractThriftClient`
