### PR TITLE
Remove unnecessary HTTP GET from ThriftHelpers::Connection::HTTP

### DIFF
--- a/lib/thrift_client/connection/http.rb
+++ b/lib/thrift_client/connection/http.rb
@@ -1,12 +1,25 @@
+# Patch Thrift 0.8.0 Gem for Ruby 1.9.3 compatibility
+if Gem.loaded_specs['thrift'].version < Gem::Version.new('0.9.0')
+  module Thrift
+    class HTTPClientTransport < BaseTransport
+      def flush
+        http = Net::HTTP.new @url.host, @url.port
+        http.use_ssl = @url.scheme == "https"
+        resp, data = http.post(@url.request_uri, @outbuf, @headers)
+        # Was: @inbuf = StringIO.new data
+        @inbuf = StringIO.new resp.body
+        @outbuf = ""
+      end
+    end
+  end
+end
+
 module ThriftHelpers
   module Connection
     class HTTP < Base
       def connect!
-        uri = parse_server(@server)
+        parse_server(@server)
         @transport = Thrift::HTTPClientTransport.new(@server)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-        http.get(uri.path)
       end
 
       private


### PR DESCRIPTION
Hi there,

I recently updated [evernote-sdk-ruby](https://github.com/evernote/evernote-sdk-ruby).  Then I found that [evernote](https://github.com/cgs/evernote) gem depends on `thrift_client` and it sends unreasonable HTTP GET many times to Evernote servers which returns:

> HTTP/1.1 405 HTTP method GET is not supported by this URL

[Thrift messages should be sent over HTTP POST](http://wiki.apache.org/thrift/ThriftIntegrationConventions).

So I removed those code and in addition, added patch for thrift 0.8.0 according to [this forum](http://discussion.evernote.com/topic/15321-evernote-ruby-thrift-client-error/).  You can see gist which is same as what I added in the last comment there.
