### PR TITLE
Extract wrapped exception class creation

### DIFF
--- a/test/thrift_client_test.rb
+++ b/test/thrift_client_test.rb
@@ -26,6 +26,13 @@ class ThriftClientTest < Test::Unit::TestCase
     assert_equal "<ThriftClient(Greeter::Client) @current_server=127.0.0.1:1463>", client.inspect
   end
 
+  def test_create_wrapped_exception_classes
+    client = Module.new
+    ThriftClient.create_wrapped_exception_classes(client, [Thrift::TransportException])
+    assert client.const_defined?(:TransportException)
+    assert client.const_get(:TransportException).new.is_a?(Thrift::TransportException)
+  end
+
   def test_live_server
     assert_nothing_raised do
       ThriftClient.new(Greeter::Client, @servers.last, @options).greeting("someone")


### PR DESCRIPTION
The wrapped exception classes are not created until ThriftClient.new
is called with the correct client class. This makes it difficult to
write code like `rescue MyThrift::Client::TransportException` because
the exception class may not exist yet.

Callers may now use ThriftClient.create_wrapped_exception_classes to
ensure the desired classes have been created.
