### PR TITLE
Specify license in gemspec

### DIFF
--- a/thrift_client.gemspec
+++ b/thrift_client.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Evan Weaver", "Ryan King", "Jeff Hodges"]
   s.homepage      = "https://github.com/twitter/thrift_client"
   s.summary       = "A Thrift client wrapper that encapsulates some common failover behavior."
+  s.license       = "Apache 2.0"
 
   s.files         = Dir["lib/**/*.rb"].to_a
   s.test_files    = Dir["test/**/*.rb"].to_a


### PR DESCRIPTION
Re: #54 

I added "Apache 2.0" in cf1c3d8c20fdba36bdea745c9f00422760de92d5 because that's what is specified in the LICENSE file. @caniszczyk, can you confirm that Apache 2.0 is the license we would like to use for this gem?
