### PR TITLE
Fix test failures in test/thrift_client_http_test.rb

### DIFF
--- a/test/greeter/server.rb
+++ b/test/greeter/server.rb
@@ -1,3 +1,5 @@
+require 'thrift/server/thin_http_server'
+
 module Greeter
   class Handler
     def greeting(name)

--- a/test/thrift_client_http_test.rb
+++ b/test/thrift_client_http_test.rb
@@ -13,7 +13,14 @@ class ThriftClientHTTPTest < Test::Unit::TestCase
     end
     # Need to give the child process a moment to open the listening socket or
     # we get occasional "could not connect" errors in tests.
-    sleep 0.20
+    100.times do
+      begin
+        sleep 0.05
+        Net::HTTP.get(URI(@servers.last))
+        break
+      rescue
+      end
+    end
   end
 
   def teardown


### PR DESCRIPTION
I was getting `bundle exec rake` failures in `test/thrift_client_http_test.rb` due to two reasons:
- thrift (>= ~0.9.2.0) doesn't export `Thrift::ThinHTTPServer.new` with `require 'thrift'` anymore.
- the server was taking longer than the allowed 0.2 seconds to start up on my machine.

This pull request fixes both issues.

---

There is actually another hardcoded timeout in `test/thrift_client_test.rb` but I've tried timeouts as low as 0.001 without problems (finally got some errors at 0.0001).

It turns out SimpleServer starts up much faster than ThinHTTPServer.
