### PR TITLE
Add api link in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,6 +39,10 @@ You need Ruby 2.1.7. Just run:
 
   sudo gem install thrift_client
 
+== Additional Documentation
+
+Additional documentation and api access can be found {here}[http://www.rubydoc.info/gems/thrift/0.9.1/Thrift]
+
 == Contributing
 
 To contribute changes:

--- a/README.rdoc
+++ b/README.rdoc
@@ -41,7 +41,7 @@ You need Ruby 2.1.7. Just run:
 
 == Additional Documentation
 
-Additional documentation and api access can be found {here}[http://www.rubydoc.info/gems/thrift/0.9.1/Thrift]
+Additional documentation and api access can be found {here}[http://www.rubydoc.info/gems/thrift/Thrift]
 
 == Contributing
 


### PR DESCRIPTION
When I was using this I did not realize that this additional documentation existed and I think it could be helpful to have a link to in the README.