### PR TITLE
Use https instead of http in urls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,7 +9,7 @@ A Thrift client wrapper that encapsulates some common failover behavior.
 * Ruby 2.1 compatibility
 * ThriftClient::Simple class, for working without generated bindings.
 
-The Github source repository is {here}[http://github.com/twitter/thrift_client/]. Patches and contributions are very welcome.
+The Github source repository is {here}[https://github.com/twitter/thrift_client/]. Patches and contributions are very welcome.
 
 == Usage
 
@@ -41,7 +41,7 @@ You need Ruby 2.1.7. Just run:
 
 == Additional Documentation
 
-Additional documentation and api access can be found {here}[http://www.rubydoc.info/gems/thrift/Thrift]
+Additional documentation and api access can be found {here}[https://www.rubydoc.info/gems/thrift/Thrift]
 
 == Contributing
 
@@ -53,10 +53,10 @@ To contribute changes:
 
 == Reporting problems
 
-The Github issue tracker is {here}[http://github.com/twitter/thrift_client/issues].
+The Github issue tracker is {here}[https://github.com/twitter/thrift_client/issues].
 
 == License
 
 Copyright 2009-2012 Twitter, Inc. See included LICENSE file.
 
-The public certificate for this gem is here[http://blog.evanweaver.com/files/evan_weaver-original-public_cert.pem].
+The public certificate for this gem is here[https://blog.evanweaver.com/files/evan_weaver-original-public_cert.pem].

--- a/test/greeter/server.rb
+++ b/test/greeter/server.rb
@@ -27,7 +27,7 @@ module Greeter
   end
 
   # client:
-  # trans = Thrift::HTTPClientTransport.new("http://127.0.0.1:9292/greeter")
+  # trans = Thrift::HTTPClientTransport.new("https://127.0.0.1:9292/greeter")
   # prot = Thrift::BinaryProtocol.new(trans)
   # c = Greeter::Client.new(prot)
   class HTTPServer

--- a/test/thrift_client_http_test.rb
+++ b/test/thrift_client_http_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('test_helper.rb', File.dirname(__FILE__))
 class ThriftClientHTTPTest < Test::Unit::TestCase
 
   def setup
-    @servers = ["http://127.0.0.1:1461/greeter", "http://127.0.0.1:1462/greeter", "http://127.0.0.1:1463/greeter"]
+    @servers = ["https://127.0.0.1:1461/greeter", "https://127.0.0.1:1462/greeter", "https://127.0.0.1:1463/greeter"]
     @socket = 1461
     @timeout = 0.2
     @options = {:protocol_extra_params => [false]}
@@ -38,7 +38,7 @@ class ThriftClientHTTPTest < Test::Unit::TestCase
   def test_valid_server
     assert_nothing_raised do
       @options.merge!({ :protocol => Thrift::BinaryProtocol, :transport => Thrift::HTTPClientTransport })
-      ThriftClient.new(Greeter::Client, "http://127.0.0.1:1463/greeter", @options).greeting("someone")
+      ThriftClient.new(Greeter::Client, "https://127.0.0.1:1463/greeter", @options).greeting("someone")
     end
   end
 


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.